### PR TITLE
Check LIST_ONLY is not 1 before dumping into usage

### DIFF
--- a/ssh_client/sshw.sh
+++ b/ssh_client/sshw.sh
@@ -590,7 +590,7 @@ done
 shift $(($OPTIND-1))
 
 # make sure we have somthing to connect to
-if [ $# -eq 0 ]; then
+if [ $# -eq 0 -a "$LIST_ONLY" -ne 1 ]; then
     usage
 fi
 


### PR DESCRIPTION
on line 593 there is a check for extra arguments, and it prevents listing of devices to work
